### PR TITLE
Remove maven instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,7 @@ From this setup, you will need two OAuth arguments to use this library:
 
 ### Installation
 
-Include as a dependency using Maven:
-
-```xml
-<dependency>
-    <groupId>com.willowtreeapps</groupId>
-    <artifactId>signinwithapplebutton</artifactId>
-    <version>0.1</version>
-</dependency>
-```
-
-…or Gradle:
+Include as a dependency using Gradle:
 
 ```groovy
 repositories {


### PR DESCRIPTION
while they'd be relevant for java users in general, pretty much nobody uses maven for android dev anymore.