### PR TITLE
Move fragmentManager as an arg to configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ At runtime, configure the button with an instance of `SignInWithAppleService`. W
 
 > According to our understanding of OpenID Connect, the "openid" scope should be included. But at this time of writing, that causes the authentication page to fail to initialize. Beta idiosyncrasies like these are documented in [How Sign in with Apple differs from OpenID Connect](https://bitbucket.org/openid/connect/src/default/How-Sign-in-with-Apple-differs-from-OpenID-Connect.md).
 
-Also supply an implementation of `SignInWithAppleClient`. With this object, you'll provide access to a FragmentManager used to present the login interface. You'll also receive callbacks for success and failure cases.
+Then configure the button with a `FragmentManager` to present the login interface, the service you created above, and a callback to receive the success/failure/cancel result.
 
 #### Example
 
@@ -127,7 +127,7 @@ override fun onCreate(savedInstanceState: Bundle?) {
     )
 
     val signInWithAppleButton = findViewById(R.id.sign_in_with_apple_button)
-    signInWithAppleButton.configure(supportFragmentManager, service, client) { result ->
+    signInWithAppleButton.configure(supportFragmentManager, service) { result ->
         when (result) {
             is SignInWithAppleResult.Success -> {
                 // Handle success
@@ -150,7 +150,7 @@ If the user completes authentication, your callback will receive a `SignInWithAp
 
 If instead there is a failure, your callback will receive a `SignInWithAppleResult.Failure` with the error.
 
-If the user dismisses the authentication screen intentionally, oy will receive a `SignInWithAppleResult.Cancel`.
+If the user dismisses the authentication screen intentionally, you will receive a `SignInWithAppleResult.Cancel`.
 
 ## Sample application
 

--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
@@ -6,15 +6,25 @@ import android.widget.Toast
 import android.widget.Toast.LENGTH_SHORT
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentManager
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleClient
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
 import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton
 
-class SampleActivity : AppCompatActivity(), SignInWithAppleClient {
+class SampleActivity : AppCompatActivity() {
 
     private lateinit var signInWithAppleButtonBlack: SignInWithAppleButton
     private lateinit var signInWithAppleButtonWhite: SignInWithAppleButton
     private lateinit var signInWithAppleButtonWhiteOutline: SignInWithAppleButton
+
+    private val callback = object: SignInWithAppleCallback {
+        override fun onSignInWithAppleSuccess(authorizationCode: String) {
+            Toast.makeText(this@SampleActivity, authorizationCode, LENGTH_SHORT).show()
+        }
+
+        override fun onSignInWithAppleFailure(error: Throwable) {
+            Log.d("SAMPLE_APP", "Received error from Apple Sign In ${error.message}")
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,10 +33,6 @@ class SampleActivity : AppCompatActivity(), SignInWithAppleClient {
         signInWithAppleButtonBlack = findViewById(R.id.sign_in_with_apple_button_black)
         signInWithAppleButtonWhite = findViewById(R.id.sign_in_with_apple_button_white)
         signInWithAppleButtonWhiteOutline = findViewById(R.id.sign_in_with_apple_button_white_outline)
-    }
-
-    override fun onStart() {
-        super.onStart()
 
         // Replace clientId and redirectUri with your own values.
         val service = SignInWithAppleService(
@@ -35,25 +41,8 @@ class SampleActivity : AppCompatActivity(), SignInWithAppleClient {
             scope = "email name"
         )
 
-        val client: SignInWithAppleClient = this
-
-        signInWithAppleButtonBlack.configure(service, client)
-        signInWithAppleButtonWhite.configure(service, client)
-        signInWithAppleButtonWhiteOutline.configure(service, client)
+        signInWithAppleButtonBlack.configure(supportFragmentManager, service, callback)
+        signInWithAppleButtonWhite.configure(supportFragmentManager, service, callback)
+        signInWithAppleButtonWhiteOutline.configure(supportFragmentManager, service, callback)
     }
-
-    // SignInWithAppleClient
-
-    override fun getFragmentManagerForSignInWithApple(): FragmentManager {
-        return supportFragmentManager
-    }
-
-    override fun onSignInWithAppleSuccess(authorizationCode: String) {
-        Toast.makeText(this, authorizationCode, LENGTH_SHORT).show()
-    }
-
-    override fun onSignInWithAppleFailure(error: Throwable) {
-        Log.d("SAMPLE_APP", "Received error from Apple Sign In ${error.message}")
-    }
-
 }

--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
@@ -5,34 +5,19 @@ import android.util.Log
 import android.widget.Toast
 import android.widget.Toast.LENGTH_SHORT
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.FragmentManager
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleResult
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
 import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton
 
 class SampleActivity : AppCompatActivity() {
 
-    private lateinit var signInWithAppleButtonBlack: SignInWithAppleButton
-    private lateinit var signInWithAppleButtonWhite: SignInWithAppleButton
-    private lateinit var signInWithAppleButtonWhiteOutline: SignInWithAppleButton
-
-    private val callback = object: SignInWithAppleCallback {
-        override fun onSignInWithAppleSuccess(authorizationCode: String) {
-            Toast.makeText(this@SampleActivity, authorizationCode, LENGTH_SHORT).show()
-        }
-
-        override fun onSignInWithAppleFailure(error: Throwable) {
-            Log.d("SAMPLE_APP", "Received error from Apple Sign In ${error.message}")
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sample)
 
-        signInWithAppleButtonBlack = findViewById(R.id.sign_in_with_apple_button_black)
-        signInWithAppleButtonWhite = findViewById(R.id.sign_in_with_apple_button_white)
-        signInWithAppleButtonWhiteOutline = findViewById(R.id.sign_in_with_apple_button_white_outline)
+        val signInWithAppleButtonBlack: SignInWithAppleButton = findViewById(R.id.sign_in_with_apple_button_black)
+        val signInWithAppleButtonWhite: SignInWithAppleButton = findViewById(R.id.sign_in_with_apple_button_white)
+        val signInWithAppleButtonWhiteOutline: SignInWithAppleButton = findViewById(R.id.sign_in_with_apple_button_white_outline)
 
         // Replace clientId and redirectUri with your own values.
         val service = SignInWithAppleService(
@@ -41,8 +26,22 @@ class SampleActivity : AppCompatActivity() {
             scope = "email name"
         )
 
-        signInWithAppleButtonBlack.configure(supportFragmentManager, service, callback)
-        signInWithAppleButtonWhite.configure(supportFragmentManager, service, callback)
-        signInWithAppleButtonWhiteOutline.configure(supportFragmentManager, service, callback)
+        signInWithAppleButtonBlack.configure(supportFragmentManager, service, ::callback)
+        signInWithAppleButtonWhite.configure(supportFragmentManager, service, ::callback)
+        signInWithAppleButtonWhiteOutline.configure(supportFragmentManager, service, ::callback)
+    }
+
+    private fun callback(result: SignInWithAppleResult) {
+        when (result) {
+            is SignInWithAppleResult.Success -> {
+                Toast.makeText(this@SampleActivity, result.authorizationCode, LENGTH_SHORT).show()
+            }
+            is SignInWithAppleResult.Failure -> {
+                Log.d("SAMPLE_APP", "Received error from Apple Sign In ${result.error.message}")
+            }
+            is SignInWithAppleResult.Cancel -> {
+                Log.d("SAMPLE_APP", "User canceled Apple Sign In")
+            }
+        }
     }
 }

--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleActivity.kt
@@ -34,7 +34,7 @@ class SampleActivity : AppCompatActivity() {
     private fun callback(result: SignInWithAppleResult) {
         when (result) {
             is SignInWithAppleResult.Success -> {
-                Toast.makeText(this@SampleActivity, result.authorizationCode, LENGTH_SHORT).show()
+                Toast.makeText(this, result.authorizationCode, LENGTH_SHORT).show()
             }
             is SignInWithAppleResult.Failure -> {
                 Log.d("SAMPLE_APP", "Received error from Apple Sign In ${result.error.message}")

--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleJavaActivity.java
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleJavaActivity.java
@@ -1,0 +1,55 @@
+package com.willowtreeapps.signinwithapple.sample;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback;
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService;
+import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton;
+
+import static android.widget.Toast.LENGTH_SHORT;
+
+public class SampleJavaActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sample);
+
+        SignInWithAppleButton signInWithAppleButtonBlack = findViewById(R.id.sign_in_with_apple_button_black);
+        SignInWithAppleButton signInWithAppleButtonWhite = findViewById(R.id.sign_in_with_apple_button_white);
+        SignInWithAppleButton signInWithAppleButtonWhiteOutline = findViewById(R.id.sign_in_with_apple_button_white_outline);
+
+        // Replace clientId and redirectUri with your own values.
+        SignInWithAppleService service = new SignInWithAppleService(
+                "com.your.client.id.here",
+                "https://your-redirect-uri.com/callback",
+                "email name"
+        );
+
+        signInWithAppleButtonBlack.configure(getSupportFragmentManager(), service, callback);
+        signInWithAppleButtonWhite.configure(getSupportFragmentManager(), service, callback);
+        signInWithAppleButtonWhiteOutline.configure(getSupportFragmentManager(), service, callback);
+    }
+
+    private final SignInWithAppleCallback callback = new SignInWithAppleCallback() {
+        @Override
+        public void onSignInWithAppleSuccess(String authorizationCode) {
+            Toast.makeText(SampleJavaActivity.this, authorizationCode, LENGTH_SHORT).show();
+        }
+
+        @Override
+        public void onSignInWithAppleFailure(Throwable error) {
+            Log.d("SAMPLE_APP", "Received error from Apple Sign In " + error.getMessage());
+        }
+
+        @Override
+        public void onSignInWithAppleCancel() {
+            Log.d("SAMPLE_APP", "User canceled Apple Sign In");
+        }
+    };
+}

--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleJavaActivity.java
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleJavaActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -38,12 +39,12 @@ public class SampleJavaActivity extends AppCompatActivity {
 
     private final SignInWithAppleCallback callback = new SignInWithAppleCallback() {
         @Override
-        public void onSignInWithAppleSuccess(String authorizationCode) {
+        public void onSignInWithAppleSuccess(@NonNull String authorizationCode) {
             Toast.makeText(SampleJavaActivity.this, authorizationCode, LENGTH_SHORT).show();
         }
 
         @Override
-        public void onSignInWithAppleFailure(Throwable error) {
+        public void onSignInWithAppleFailure(@NonNull Throwable error) {
             Log.d("SAMPLE_APP", "Received error from Apple Sign In " + error.getMessage());
         }
 

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleCallback.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleCallback.kt
@@ -1,6 +1,10 @@
 package com.willowtreeapps.signinwithapplebutton
 
 interface SignInWithAppleCallback {
+
     fun onSignInWithAppleSuccess(authorizationCode: String)
+
     fun onSignInWithAppleFailure(error: Throwable)
+
+    fun onSignInWithAppleCancel()
 }

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleClient.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleClient.kt
@@ -1,7 +1,0 @@
-package com.willowtreeapps.signinwithapplebutton
-
-import androidx.fragment.app.FragmentManager
-
-interface SignInWithAppleClient : SignInWithAppleCallback {
-    fun getFragmentManagerForSignInWithApple(): FragmentManager
-}

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleResult.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleResult.kt
@@ -1,0 +1,9 @@
+package com.willowtreeapps.signinwithapplebutton
+
+sealed class SignInWithAppleResult {
+    data class Success(val authorizationCode: String) : SignInWithAppleResult()
+
+    data class Failure(val error: Throwable) : SignInWithAppleResult()
+
+    object Cancel : SignInWithAppleResult()
+}

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleService.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleService.kt
@@ -3,6 +3,7 @@ package com.willowtreeapps.signinwithapplebutton
 import android.net.Uri
 import android.os.Parcel
 import android.os.Parcelable
+import androidx.fragment.app.FragmentManager
 import java.util.*
 
 class SignInWithAppleService(
@@ -20,7 +21,7 @@ class SignInWithAppleService(
             parcel.readString() ?: "invalid",
             parcel.readString() ?: "invalid",
             parcel.readString() ?: "invalid"
-        ) {}
+        )
 
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeString(authenticationUri)
@@ -65,5 +66,4 @@ class SignInWithAppleService(
 
         return AuthenticationAttempt(authenticationUri, redirectUri, state)
     }
-
 }

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClient.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClient.kt
@@ -4,13 +4,13 @@ import android.util.Log
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleResult
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
 import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton.Companion.SIGN_IN_WITH_APPLE_LOG_TAG
 
 internal class SignInWebViewClient(
     private val attempt: SignInWithAppleService.AuthenticationAttempt,
-    private val callback: SignInWithAppleCallback
+    private val callback: (SignInWithAppleResult) -> Unit
 ) : WebViewClient() {
 
     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
@@ -32,13 +32,13 @@ internal class SignInWebViewClient(
 
                 when {
                     codeParameter == null -> {
-                        callback.onSignInWithAppleFailure(IllegalArgumentException("code not returned"))
+                        callback(SignInWithAppleResult.Failure(IllegalArgumentException("code not returned")))
                     }
                     stateParameter != attempt.state -> {
-                        callback.onSignInWithAppleFailure(IllegalArgumentException("state does not match"))
+                        callback(SignInWithAppleResult.Failure(IllegalArgumentException("state does not match")))
                     }
                     else -> {
-                        callback.onSignInWithAppleSuccess(codeParameter)
+                        callback(SignInWithAppleResult.Success(codeParameter))
                     }
                 }
 

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewDialogFragment.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewDialogFragment.kt
@@ -97,8 +97,8 @@ internal class SignInWebViewDialogFragment : DialogFragment() {
         dialog?.window?.setLayout(MATCH_PARENT, MATCH_PARENT)
     }
 
-    override fun onDismiss(dialog: DialogInterface?) {
-        super.onDismiss(dialog)
+    override fun onCancel(dialog: DialogInterface?) {
+        super.onCancel(dialog)
         onCallback(SignInWithAppleResult.Cancel)
     }
 

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWithAppleButton.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWithAppleButton.kt
@@ -122,7 +122,7 @@ class SignInWithAppleButton @JvmOverloads constructor(
 
         val callback = callback
         if (callback == null) {
-            Log.w(SIGN_IN_WITH_APPLE_LOG_TAG, "Client is not configured")
+            Log.w(SIGN_IN_WITH_APPLE_LOG_TAG, "Callback is not configured")
             return
         }
 

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWithAppleButton.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWithAppleButton.kt
@@ -8,8 +8,9 @@ import android.view.LayoutInflater
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentManager
 import com.willowtreeapps.signinwithapplebutton.R
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleClient
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
 
 class SignInWithAppleButton @JvmOverloads constructor(
@@ -22,7 +23,8 @@ class SignInWithAppleButton @JvmOverloads constructor(
     }
 
     private var service: SignInWithAppleService? = null
-    private var client: SignInWithAppleClient? = null
+    private var client: SignInWithAppleCallback? = null
+    private var fragmentManager: FragmentManager? = null
 
     init {
         LayoutInflater.from(context).inflate(R.layout.sign_in_with_apple_button, this, true)
@@ -73,11 +75,11 @@ class SignInWithAppleButton @JvmOverloads constructor(
         }
     }
 
-    fun configure(service: SignInWithAppleService, client: SignInWithAppleClient) {
+    fun configure(fragmentManager: FragmentManager, service: SignInWithAppleService, client: SignInWithAppleCallback) {
+        this.fragmentManager = fragmentManager
         this.service = service
         this.client = client
 
-        val fragmentManager = client.getFragmentManagerForSignInWithApple()
         val fragmentIfCreated = fragmentManager.findFragmentByTag(fragmentTag) as? SignInWebViewDialogFragment
         fragmentIfCreated?.configure(client)
     }
@@ -101,7 +103,7 @@ class SignInWithAppleButton @JvmOverloads constructor(
         val fragment = SignInWebViewDialogFragment.newInstance(service.buildAuthenticationAttempt())
         fragment.configure(client)
 
-        fragment.show(client.getFragmentManagerForSignInWithApple(), fragmentTag)
+        fragment.show(fragmentManager, fragmentTag)
     }
 
 }

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWithAppleButton.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWithAppleButton.kt
@@ -11,6 +11,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
 import com.willowtreeapps.signinwithapplebutton.R
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleResult
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
 
 class SignInWithAppleButton @JvmOverloads constructor(
@@ -22,9 +23,9 @@ class SignInWithAppleButton @JvmOverloads constructor(
         const val SIGN_IN_WITH_APPLE_LOG_TAG = "SIGN_IN_WITH_APPLE"
     }
 
-    private var service: SignInWithAppleService? = null
-    private var client: SignInWithAppleCallback? = null
     private var fragmentManager: FragmentManager? = null
+    private var service: SignInWithAppleService? = null
+    private var callback: ((SignInWithAppleResult) -> Unit)? = null
 
     init {
         LayoutInflater.from(context).inflate(R.layout.sign_in_with_apple_button, this, true)
@@ -33,7 +34,8 @@ class SignInWithAppleButton @JvmOverloads constructor(
     private val textView: TextView = findViewById(R.id.textView)
 
     init {
-        val attributes = context.theme.obtainStyledAttributes(attrs, R.styleable.SignInWithAppleButton, 0, 0)
+        val attributes =
+            context.theme.obtainStyledAttributes(attrs, R.styleable.SignInWithAppleButton, 0, 0)
 
         val colorStyleIndex =
             attributes.getInt(
@@ -65,7 +67,12 @@ class SignInWithAppleButton @JvmOverloads constructor(
         val icon = ContextCompat.getDrawable(context, colorStyle.icon)?.mutate()
 
         if (icon != null) {
-            icon.setBounds(0, iconVerticalOffset, icon.intrinsicWidth, icon.intrinsicHeight + iconVerticalOffset)
+            icon.setBounds(
+                0,
+                iconVerticalOffset,
+                icon.intrinsicWidth,
+                icon.intrinsicHeight + iconVerticalOffset
+            )
 
             textView.setCompoundDrawablesRelative(icon, null, null, null)
         }
@@ -75,13 +82,32 @@ class SignInWithAppleButton @JvmOverloads constructor(
         }
     }
 
-    fun configure(fragmentManager: FragmentManager, service: SignInWithAppleService, client: SignInWithAppleCallback) {
+    fun configure(
+        fragmentManager: FragmentManager,
+        service: SignInWithAppleService,
+        callback: SignInWithAppleCallback
+    ) {
+        configure(fragmentManager, service) { result ->
+            when (result) {
+                is SignInWithAppleResult.Success -> callback.onSignInWithAppleSuccess(result.authorizationCode)
+                is SignInWithAppleResult.Failure -> callback.onSignInWithAppleFailure(result.error)
+                is SignInWithAppleResult.Cancel -> callback.onSignInWithAppleCancel()
+            }
+        }
+    }
+
+    fun configure(
+        fragmentManager: FragmentManager,
+        service: SignInWithAppleService,
+        callback: (SignInWithAppleResult) -> Unit
+    ) {
         this.fragmentManager = fragmentManager
         this.service = service
-        this.client = client
+        this.callback = callback
 
-        val fragmentIfCreated = fragmentManager.findFragmentByTag(fragmentTag) as? SignInWebViewDialogFragment
-        fragmentIfCreated?.configure(client)
+        val fragmentIfCreated =
+            fragmentManager.findFragmentByTag(fragmentTag) as? SignInWebViewDialogFragment
+        fragmentIfCreated?.configure(callback)
     }
 
     private val fragmentTag: String
@@ -94,14 +120,14 @@ class SignInWithAppleButton @JvmOverloads constructor(
             return
         }
 
-        val client = client
-        if (client == null) {
+        val callback = callback
+        if (callback == null) {
             Log.w(SIGN_IN_WITH_APPLE_LOG_TAG, "Client is not configured")
             return
         }
 
         val fragment = SignInWebViewDialogFragment.newInstance(service.buildAuthenticationAttempt())
-        fragment.configure(client)
+        fragment.configure(callback)
 
         fragment.show(fragmentManager, fragmentTag)
     }


### PR DESCRIPTION
Think it's more clean to provide it directly instead of a result of a
callback. This also means the callback does not need to depend on the
fragment manager which can be important depending on where you have it
implemented.