### PR TITLE
Fix for the problem 'response_mode must be form_post when name or email scope is requested.'

### DIFF
--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleService.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleService.kt
@@ -77,6 +77,7 @@ class SignInWithAppleService(
                         appendQueryParameter("client_id", configuration.clientId)
                         appendQueryParameter("redirect_uri", configuration.redirectUri)
                         appendQueryParameter("scope", configuration.scope)
+                        appendQueryParameter("response_mode", "form_post")
                         appendQueryParameter("state", state)
                     }
                     .build()


### PR DESCRIPTION
'response_mode' added as parameter to fix the problem 'response_mode must be form_post when name or email scope is requested.' when you use the scope 'email' or 'name'

I tested it, and it works!