### PR TITLE
Suggestions for query parameters and handling response in detail 

### DIFF
--- a/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleJavaActivity.java
+++ b/sample/src/main/java/com/willowtreeapps/signinwithapple/sample/SampleJavaActivity.java
@@ -10,7 +10,6 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleConfiguration;
 import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback;
-import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService;
 import com.willowtreeapps.signinwithapplebutton.view.SignInWithAppleButton;
 
 import static android.widget.Toast.LENGTH_SHORT;
@@ -35,8 +34,14 @@ public class SampleJavaActivity extends AppCompatActivity {
 
         SignInWithAppleCallback callback = new SignInWithAppleCallback() {
             @Override
-            public void onSignInWithAppleSuccess(@NonNull String authorizationCode) {
+            public void onSignInWithAppleSuccess(
+                    @NonNull String authorizationCode,
+                    @NonNull String idToken,
+                    @Nullable String email,
+                    @Nullable String firstName,
+                    @Nullable String lastName) {
                 Toast.makeText(SampleJavaActivity.this, authorizationCode, LENGTH_SHORT).show();
+
             }
 
             @Override

--- a/signinwithapplebutton/build.gradle
+++ b/signinwithapplebutton/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    testImplementation "io.mockk:mockk:1.9"
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleCallback.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleCallback.kt
@@ -2,7 +2,13 @@ package com.willowtreeapps.signinwithapplebutton
 
 interface SignInWithAppleCallback {
 
-    fun onSignInWithAppleSuccess(authorizationCode: String)
+    fun onSignInWithAppleSuccess(
+        authorizationCode: String,
+        idToken: String,
+        email: String? = null,
+        firstName: String? = null,
+        lastName: String? = null
+    )
 
     fun onSignInWithAppleFailure(error: Throwable)
 
@@ -12,7 +18,9 @@ interface SignInWithAppleCallback {
 internal fun SignInWithAppleCallback.toFunction(): (SignInWithAppleResult) -> Unit =
     { result ->
         when (result) {
-            is SignInWithAppleResult.Success -> onSignInWithAppleSuccess(result.authorizationCode)
+            is SignInWithAppleResult.Success -> onSignInWithAppleSuccess(
+                result.authorizationCode, result.idToken, result.email, result.firstName, result.lastName
+            )
             is SignInWithAppleResult.Failure -> onSignInWithAppleFailure(result.error)
             is SignInWithAppleResult.Cancel -> onSignInWithAppleCancel()
         }

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleResult.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleResult.kt
@@ -1,7 +1,10 @@
 package com.willowtreeapps.signinwithapplebutton
 
 sealed class SignInWithAppleResult {
-    data class Success(val authorizationCode: String) : SignInWithAppleResult()
+    data class Success(
+        val authorizationCode: String,
+        val idToken: String
+    ) : SignInWithAppleResult()
 
     data class Failure(val error: Throwable) : SignInWithAppleResult()
 

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleResult.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleResult.kt
@@ -3,7 +3,10 @@ package com.willowtreeapps.signinwithapplebutton
 sealed class SignInWithAppleResult {
     data class Success(
         val authorizationCode: String,
-        val idToken: String
+        val idToken: String,
+        val email: String? = null,
+        val firstName: String? = null,
+        val lastName: String? = null
     ) : SignInWithAppleResult()
 
     data class Failure(val error: Throwable) : SignInWithAppleResult()

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleService.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleService.kt
@@ -72,7 +72,7 @@ class SignInWithAppleService(
                 val authenticationUri = Uri
                     .parse("https://appleid.apple.com/auth/authorize")
                     .buildUpon().apply {
-                        appendQueryParameter("response_type", "code")
+                        appendQueryParameter("response_type", "code id_token")
                         appendQueryParameter("v", "1.1.6")
                         appendQueryParameter("client_id", configuration.clientId)
                         appendQueryParameter("redirect_uri", configuration.redirectUri)

--- a/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClient.kt
+++ b/signinwithapplebutton/src/main/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClient.kt
@@ -39,17 +39,18 @@ internal class SignInWebViewClient(
                 Log.d(SIGN_IN_WITH_APPLE_LOG_TAG, "Web view was forwarded to redirect URI")
 
                 val codeParameter = url.getQueryParameter("code")
+                val idTokenParameter = url.getQueryParameter("id_token")
                 val stateParameter = url.getQueryParameter("state")
 
                 when {
-                    codeParameter == null -> {
-                        callback(SignInWithAppleResult.Failure(IllegalArgumentException("code not returned")))
+                    codeParameter == null || idTokenParameter == null -> {
+                        callback(SignInWithAppleResult.Failure(IllegalArgumentException("code or idToken not returned")))
                     }
                     stateParameter != attempt.state -> {
                         callback(SignInWithAppleResult.Failure(IllegalArgumentException("state does not match")))
                     }
                     else -> {
-                        callback(SignInWithAppleResult.Success(codeParameter))
+                        callback(SignInWithAppleResult.Success(codeParameter, idTokenParameter))
                     }
                 }
 

--- a/signinwithapplebutton/src/test/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleServiceTest.kt
+++ b/signinwithapplebutton/src/test/java/com/willowtreeapps/signinwithapplebutton/SignInWithAppleServiceTest.kt
@@ -42,7 +42,7 @@ class SignInWithAppleServiceTest {
         )
 
         assertEquals(
-            "https://appleid.apple.com/auth/authorize?response_type=code&v=1.1.6&client_id=com.your.client.id.here&redirect_uri=https%3A%2F%2Fyour-redirect-uri.com%2Fcallback&scope=email&state=state&response_mode=form_post",
+            "https://appleid.apple.com/auth/authorize?response_type=code%20id_token&v=1.1.6&client_id=com.your.client.id.here&redirect_uri=https%3A%2F%2Fyour-redirect-uri.com%2Fcallback&scope=email&state=state&response_mode=form_post",
             attempt.authenticationUri
         )
         assertEquals("https://your-redirect-uri.com/callback", attempt.redirectUri)

--- a/signinwithapplebutton/src/test/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClientTest.kt
+++ b/signinwithapplebutton/src/test/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClientTest.kt
@@ -33,7 +33,7 @@ class SignInWebViewClientTest {
             every { state } returns "state"
         }
         callback = mockkClass(SignInWithAppleCallback::class) {
-            every { onSignInWithAppleSuccess(any()) } just runs
+            every { onSignInWithAppleSuccess(any(), any(), any(), any(), any()) } just runs
             every { onSignInWithAppleFailure(any()) } just runs
         }.toFunction()
         client = SignInWebViewClient(attempt, callback)

--- a/signinwithapplebutton/src/test/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClientTest.kt
+++ b/signinwithapplebutton/src/test/java/com/willowtreeapps/signinwithapplebutton/view/SignInWebViewClientTest.kt
@@ -1,0 +1,165 @@
+package com.willowtreeapps.signinwithapplebutton.view
+
+import android.annotation.TargetApi
+import android.os.Build
+import android.os.Build.VERSION_CODES.N
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleCallback
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleResult
+import com.willowtreeapps.signinwithapplebutton.SignInWithAppleService
+import com.willowtreeapps.signinwithapplebutton.toFunction
+import io.mockk.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class SignInWebViewClientTest {
+
+    private lateinit var attempt: SignInWithAppleService.AuthenticationAttempt
+    private lateinit var callback: (SignInWithAppleResult) -> Unit
+    private lateinit var client: SignInWebViewClient
+
+    @Before
+    fun tearUp() {
+        attempt = mockkClass(SignInWithAppleService.AuthenticationAttempt::class) {
+            every { redirectUri } returns "https://test.com/redirect"
+            every { state } returns "state"
+        }
+        callback = mockkClass(SignInWithAppleCallback::class) {
+            every { onSignInWithAppleSuccess(any()) } just runs
+            every { onSignInWithAppleFailure(any()) } just runs
+        }.toFunction()
+        client = SignInWebViewClient(attempt, callback)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun success_result_parsed_with_user_successfully() {
+        val overrided = client.shouldOverrideUrlLoading(
+            null,
+            "https://test.com/redirect?state=state&code=code&id_token=id_token&user=%7B%22name%22%3A%7B%22firstName%22%3A%22Test%22%2C%22lastName%22%3A%22User%22%7D%2C%22email%22%3A%22test%40test.com%22%7D"
+        )
+        assertEquals(true, overrided)
+        verify {
+            callback(
+                SignInWithAppleResult.Success(
+                    "code", "id_token", "test@test.com", "Test", "User"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun success_result_parsed_with_no_user_successfully() {
+        val overrided = client.shouldOverrideUrlLoading(
+            null,
+            "https://test.com/redirect?state=state&code=code&id_token=id_token"
+        )
+        assertEquals(true, overrided)
+        verify {
+            callback(
+                SignInWithAppleResult.Success(
+                    "code", "id_token", null, null, null
+                )
+            )
+        }
+    }
+
+    @Test
+    fun success_result_parsed_with_invalid_user_successfully() {
+        val overrided = client.shouldOverrideUrlLoading(
+            null,
+            "https://test.com/redirect?state=state&code=code&id_token=id_token&user=asdf"
+        )
+        assertEquals(true, overrided)
+        verify {
+            callback(
+                SignInWithAppleResult.Success(
+                    "code", "id_token", null, null, null
+                )
+            )
+        }
+    }
+
+    @Test
+    fun success_result_parsed_with_invalid_user_name_and_valid_email_successfully() {
+        val overrided = client.shouldOverrideUrlLoading(
+            null,
+            "https://test.com/redirect?state=state&code=code&id_token=id_token&user=%7B%22name%22%3A+%22asdf%22%2C+%22email%22%3A+%22test@test.com%22%7D"
+        )
+        assertEquals(true, overrided)
+        verify {
+            callback(
+                SignInWithAppleResult.Success(
+                    "code", "id_token", "test@test.com", null, null
+                )
+            )
+        }
+    }
+
+    @Test
+    fun null_url_will_not_be_overrided() {
+        assertEquals(
+            false,
+            client.shouldOverrideUrlLoading(null, mockkClass(WebResourceRequest::class) {
+                every { url } returns null
+            })
+        )
+    }
+
+    @Test
+    fun url_contains_apple_id_url_will_be_loaded_manually() {
+        val appleIdUrl = "https://appleid.apple.com"
+        val webView = mockkClass(WebView::class) {
+            every { loadUrl(any()) } just runs
+        }
+        val overrided = client.shouldOverrideUrlLoading(webView, appleIdUrl)
+
+        assertEquals(true, overrided)
+        verify {
+            webView.loadUrl(appleIdUrl)
+        }
+    }
+
+    @Test
+    fun url_without_apple_id_url_and_redirect_url_will_not_be_overrided() {
+        val overrided = client.shouldOverrideUrlLoading(null, "https:/someurl.com")
+
+        assertEquals(false, overrided)
+    }
+
+    @Test
+    fun url_without_id_token_parameter_failed() {
+        val overrided = client.shouldOverrideUrlLoading(null, "https://test.com/redirect?state=state&code=code")
+
+        assertEquals(true, overrided)
+        verify { callback(SignInWithAppleResult.Failure(any())) }
+    }
+
+    @Test
+    fun url_without_code_parameter_failed() {
+        val overrided = client.shouldOverrideUrlLoading(null, "https://test.com/redirect?state=state&id_token=id_token")
+
+        assertEquals(true, overrided)
+        verify { callback(SignInWithAppleResult.Failure(any())) }
+    }
+
+    @Test
+    fun url_with_wrong_state_parameter_failed() {
+        val overrided = client.shouldOverrideUrlLoading(null, "https://test.com/redirect?state=wrong_state")
+
+        assertEquals(true, overrided)
+        verify { callback(SignInWithAppleResult.Failure(any())) }
+    }
+}


### PR DESCRIPTION
[Apple's official documentation for other platforms](https://developer.apple.com/documentation/signinwithapplejs/incorporating_sign_in_with_apple_into_other_platforms)

This PR contains three subjects.

## Add id_token in response_type
For our service, we need id_token rather than authorization code. we found that official documentation said "id_token" can be one of parameter for "response_type". With this change, we can get code and token finally. I guess this addition will help other developers! (depending on their backend implementation)

## Get user data from response
According to official documentation, user's data is returned with encoded json string in query parameter. So, I tried to parse this data in SignInWebViewClient. (There is some unexpected behavior that only first attempt returns data with query parameter) 

## (NEW) mockk : mocking library for kotlin
I added mockk, mocking library for kotlin. It is very useful and easy to make situation that we want to test. Maybe it is easy to understand my test implementation to verify specific situation!

